### PR TITLE
Fix all deprecation warnings

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -16,7 +16,7 @@
 
 ```mbt
 ///|
-typealias @jmop.(Object, Promise, Function)
+using @jmop {type Object, type Promise, type Function}
 
 ///|
 fn init {

--- a/any.mbt
+++ b/any.mbt
@@ -48,7 +48,7 @@ pub fn[T] Any::from(x : T) -> Any {
 /// Otherwise, raises an `UnwrapUndefined` or `UnwrapNull` error.
 #callsite(autofill(loc))
 pub fn Any::unwrap(x : Self, loc~ : SourceLoc) -> Value raise {
-  x.inner().unwrap_value(loc~)
+  x.0.unwrap_value(loc~)
 }
 
 ///|

--- a/nullable.mbt
+++ b/nullable.mbt
@@ -28,11 +28,13 @@ pub fn Nullable::unwrap_value(
 }
 
 ///|
+#as_free_fn(nullable)
 pub fn[T] Nullable::from(x : T) -> Nullable[T] {
   identity(x)
 }
 
 ///|
+#as_free_fn(null)
 pub fn[T] Nullable::null() -> Nullable[T] {
   identity(ffi_null())
 }
@@ -46,9 +48,6 @@ pub fn[T] Nullable::to_option(self : Self[T]) -> T? {
     Some(identity(self))
   }
 }
-
-///|
-pub fnalias Nullable::(from as nullable, null)
 
 ///|
 extern "js" fn ffi_object_is_null(x : Any) -> Bool = "(x) => x === null"

--- a/object.mbt
+++ b/object.mbt
@@ -76,7 +76,7 @@ pub fn Object::get(
   prop : &IsStringOrSymbol,
   loc~ : SourceLoc,
 ) -> Value raise {
-  ffi_object_get(self.as_value(), prop.as_any()).inner().unwrap_value(loc~)
+  ffi_object_get(self.as_value(), prop.as_any()).0.unwrap_value(loc~)
 }
 
 ///|
@@ -187,9 +187,9 @@ pub fn Object::instance_of(
 ) -> Bool {
   let ctor = ctor.as_value()
   let ctor = global_this.get_function(ctor.to_string()).as_value() catch {
-    InvalidCast(_) => ctor
-    _ => panic()
-  }
+      InvalidCast(_) => ctor
+      _ => panic()
+    }
   ffi_instanceof(self.as_any(), ctor)
 }
 

--- a/optional.mbt
+++ b/optional.mbt
@@ -31,11 +31,13 @@ pub fn Optional::unwrap_value(
 }
 
 ///|
+#as_free_fn(optional)
 pub fn[T] Optional::from(x : T) -> Optional[T] {
   identity(x)
 }
 
 ///|
+#as_free_fn(undefined)
 pub fn[T] Optional::undefined() -> Optional[T] {
   identity(ffi_undefined())
 }
@@ -56,9 +58,6 @@ pub fn[T] Optional::from_option(opt : T?) -> Self[T] {
     Some(x) => identity(x)
   }
 }
-
-///|
-pub fnalias Optional::(from as optional, undefined)
 
 ///|
 extern "js" fn ffi_is_undefined(x : Any) -> Bool = "(x) => x === undefined"

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -19,10 +19,6 @@ fn new(Function, Array[&IsAny]) -> Object raise
 
 fn[T] no_raise(() -> T raise) -> T
 
-fn[T] nullable(T) -> Nullable[T]
-
-fn[T] optional(T) -> Optional[T]
-
 fn try_launch(async () -> Unit) -> Unit
 
 // Errors
@@ -151,9 +147,10 @@ impl IsObject for JsTypeError
 impl IsValue for JsTypeError
 
 type Nullable[T]
+#as_free_fn(nullable)
 fn[T] Nullable::from(T) -> Self[T]
+#as_free_fn(null)
 fn[T] Nullable::null() -> Self[T]
-fnalias Nullable::null
 fn[T] Nullable::to_option(Self[T]) -> T?
 #callsite(autofill(loc))
 fn[T] Nullable::unwrap(Self[T], loc~ : SourceLoc) -> T raise UnwrapNull
@@ -199,11 +196,12 @@ impl IsStringOrFunctionOrObject for Object
 impl IsValue for Object
 
 type Optional[T]
+#as_free_fn(optional)
 fn[T] Optional::from(T) -> Self[T]
 fn[T] Optional::from_option(T?) -> Self[T]
 fn[T] Optional::to_option(Self[T]) -> T?
+#as_free_fn(undefined)
 fn[T] Optional::undefined() -> Self[T]
-fnalias Optional::undefined
 #callsite(autofill(loc))
 fn[T] Optional::unwrap(Self[T], loc~ : SourceLoc) -> T raise UnwrapUndefined
 #callsite(autofill(loc))

--- a/value.mbt
+++ b/value.mbt
@@ -181,9 +181,9 @@ pub fn Value::instance_of(
 ) -> Bool {
   let ctor = ctor.as_value()
   let ctor = global_this.get_function(ctor.to_string()).as_value() catch {
-    InvalidCast(_) => ctor
-    _ => panic()
-  }
+      InvalidCast(_) => ctor
+      _ => panic()
+    }
   ffi_instanceof(self.as_any(), ctor)
 }
 


### PR DESCRIPTION
- Replace .inner() with .0 for struct field access in any.mbt and object.mbt
- Replace fnalias with #as_free_fn attribute for nullable/null and optional/undefined
- Replace typealias syntax with using syntax in README.mbt.md