### PR TITLE
Format suberror declarations and refresh generated metadata

### DIFF
--- a/src/dyn_cast.mbt
+++ b/src/dyn_cast.mbt
@@ -4,7 +4,9 @@ pub(open) trait DynCast: IsValue {
 }
 
 ///|
-suberror DynCastFailed String?
+suberror DynCastFailed {
+  DynCastFailed(String?)
+}
 
 ///|
 pub fn[T] fail_cast(target? : String) -> T raise DynCastFailed {

--- a/src/errors.mbt
+++ b/src/errors.mbt
@@ -1,44 +1,70 @@
 ///|
-pub suberror EvalError Error_
+pub suberror EvalError {
+  EvalError(Error_)
+}
 
 ///|
-pub suberror RangeError Error_
+pub suberror RangeError {
+  RangeError(Error_)
+}
 
 ///|
-pub suberror TypeError Error_
+pub suberror TypeError {
+  TypeError(Error_)
+}
 
 ///|
-pub suberror ReferenceError Error_
+pub suberror ReferenceError {
+  ReferenceError(Error_)
+}
 
 ///|
-pub suberror SyntaxError Error_
+pub suberror SyntaxError {
+  SyntaxError(Error_)
+}
 
 ///|
-pub suberror URIError Error_
+pub suberror URIError {
+  URIError(Error_)
+}
 
 ///|
-pub suberror AggregateError Error_
+pub suberror AggregateError {
+  AggregateError(Error_)
+}
 
 ///|
-pub suberror InternalError Error_
+pub suberror InternalError {
+  InternalError(Error_)
+}
 
 ///|
-pub(all) suberror InvalidCast (SourceLoc, Value, String?)
+pub(all) suberror InvalidCast {
+  InvalidCast((SourceLoc, Value, String?))
+}
 
 ///|
-pub(all) suberror InvalidField (SourceLoc, Value, String)
+pub(all) suberror InvalidField {
+  InvalidField((SourceLoc, Value, String))
+}
 
 ///|
 // pub suberror RuntimeError Value
 
 ///|
-pub suberror UnwrapNull SourceLoc
+pub suberror UnwrapNull {
+  UnwrapNull(SourceLoc)
+}
 
 ///|
-pub suberror UnwrapUndefined SourceLoc
+pub suberror UnwrapUndefined {
+  UnwrapUndefined(SourceLoc)
+}
 
 ///|
-pub suberror InvalidNestedPromise SourceLoc
+pub suberror InvalidNestedPromise {
+  InvalidNestedPromise(SourceLoc)
+}
 
 ///|
 pub impl Show for EvalError with output(self, buf) {

--- a/src/global.mbt
+++ b/src/global.mbt
@@ -2,7 +2,9 @@
 pub let global_this : Object = ffi_global_this()
 
 ///|
-pub suberror ArityMismatch ArityMismatchInfo
+pub suberror ArityMismatch {
+  ArityMismatch(ArityMismatchInfo)
+}
 
 ///|
 pub struct ArityMismatchInfo {

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -29,70 +29,98 @@ pub fn try_launch(async () -> Unit) -> Unit
 pub fn[T] unsafe_to_any(T) -> Optional[Nullable[Value]]
 
 // Errors
-pub suberror AggregateError Error_
+pub suberror AggregateError {
+  AggregateError(Error_)
+}
 pub impl IsError for AggregateError
 pub impl IsObject for AggregateError
 pub impl IsValue for AggregateError
 pub impl Show for AggregateError
 
-pub suberror ArityMismatch ArityMismatchInfo
+pub suberror ArityMismatch {
+  ArityMismatch(ArityMismatchInfo)
+}
 
 type DynCastFailed
 
-pub suberror EvalError Error_
+pub suberror EvalError {
+  EvalError(Error_)
+}
 pub impl IsError for EvalError
 pub impl IsObject for EvalError
 pub impl IsValue for EvalError
 pub impl Show for EvalError
 
-pub suberror InternalError Error_
+pub suberror InternalError {
+  InternalError(Error_)
+}
 pub impl IsError for InternalError
 pub impl IsObject for InternalError
 pub impl IsValue for InternalError
 pub impl Show for InternalError
 
-pub(all) suberror InvalidCast (SourceLoc, Value, String?)
+pub(all) suberror InvalidCast {
+  InvalidCast((SourceLoc, Value, String?))
+}
 pub impl Show for InvalidCast
 
-pub(all) suberror InvalidField (SourceLoc, Value, String)
+pub(all) suberror InvalidField {
+  InvalidField((SourceLoc, Value, String))
+}
 pub impl Show for InvalidField
 
-pub suberror InvalidNestedPromise SourceLoc
+pub suberror InvalidNestedPromise {
+  InvalidNestedPromise(SourceLoc)
+}
 pub impl Show for InvalidNestedPromise
 
-pub suberror RangeError Error_
+pub suberror RangeError {
+  RangeError(Error_)
+}
 pub impl IsError for RangeError
 pub impl IsObject for RangeError
 pub impl IsValue for RangeError
 pub impl Show for RangeError
 
-pub suberror ReferenceError Error_
+pub suberror ReferenceError {
+  ReferenceError(Error_)
+}
 pub impl IsError for ReferenceError
 pub impl IsObject for ReferenceError
 pub impl IsValue for ReferenceError
 pub impl Show for ReferenceError
 
-pub suberror SyntaxError Error_
+pub suberror SyntaxError {
+  SyntaxError(Error_)
+}
 pub impl IsError for SyntaxError
 pub impl IsObject for SyntaxError
 pub impl IsValue for SyntaxError
 pub impl Show for SyntaxError
 
-pub suberror TypeError Error_
+pub suberror TypeError {
+  TypeError(Error_)
+}
 pub impl IsError for TypeError
 pub impl IsObject for TypeError
 pub impl IsValue for TypeError
 pub impl Show for TypeError
 
-pub suberror URIError Error_
+pub suberror URIError {
+  URIError(Error_)
+}
 pub impl IsError for URIError
 pub impl IsObject for URIError
 pub impl IsValue for URIError
 pub impl Show for URIError
 
-pub suberror UnwrapNull SourceLoc
+pub suberror UnwrapNull {
+  UnwrapNull(SourceLoc)
+}
 
-pub suberror UnwrapUndefined SourceLoc
+pub suberror UnwrapUndefined {
+  UnwrapUndefined(SourceLoc)
+}
 pub impl Show for UnwrapUndefined
 
 // Types and methods


### PR DESCRIPTION
### Motivation
- Migrate deprecated inline `suberror` declarations to the new block form to silence deprecation warnings and keep error shapes explicit. 
- Ensure project formatting and generated package metadata reflect the updated declarations so tooling and consumers see the new shapes.

### Description
- Converted short-form `suberror Name Type` entries to block-form `suberror Name { Name(Type) }` in `src/dyn_cast.mbt`, `src/errors.mbt`, and `src/global.mbt` to preserve existing variants while updating syntax. 
- Regenerated `src/pkg.generated.mbti` so the package metadata matches the formatted suberror declarations. 
- Ran the Moon formatter to apply canonical layout to the updated declarations.

### Testing
- Ran `~/.moon/bin/moon check` which completed successfully. 
- Ran `~/.moon/bin/moon fmt` initially which failed due to `moonfmt` not being in `PATH`, and then ran `PATH=$HOME/.moon/bin:$PATH ~/.moon/bin/moon fmt` which completed successfully. 
- Ran `~/.moon/bin/moon info` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967014c254483338fc0d24c32ad9b40)